### PR TITLE
Better handle missing chromosomes

### DIFF
--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -7,6 +7,7 @@ RAM.
 
 """
 from __future__ import print_function
+import sys
 import argparse
 import gzip
 import time
@@ -66,6 +67,9 @@ def get_snps(snpdir, chrom_only = None):
             pos, ref, alt = line.split()
             pos = int(pos) - 1
             snp_dict[chrom][pos] = "".join([ref, alt])
+    if len(snp_dict) == 0:
+        print("ERROR: Could not find appropriate SNP files")
+        sys.exit(1)
     return snp_dict
 
 def get_indels(snp_dict):
@@ -486,8 +490,9 @@ if __name__ == "__main__":
                     'sample in question (which need to be checked for '
                     'mappability issues).  This directory should contain '
                     'sorted files of SNPs separated by chromosome and named: '
-                    'chr<#>.snps.txt.gz. These files should contain 3 columns: '
-                    'position RefAllele AltAllele')
+                    '<chrname>.snps.txt.gz (where chrname is the name of the '
+                    'chromosomes in the bam file). These files should contain '
+                    '3 columns: position RefAllele AltAllele')
 
     parser.add_argument("snp_dir", action='store', help=snp_dir_help)
 

--- a/mapping/find_intersecting_snps.py
+++ b/mapping/find_intersecting_snps.py
@@ -373,7 +373,7 @@ def assign_reads(insam, snp_dict, indel_dict, is_paired=True, phased=False, keep
         total_pairs = read_results['total']//2
         print("  Total input reads:", total_pairs, "pairs.")
         print("  Unpaired reads:", len(unpaired_reads[0]) + len(unpaired_reads[1]), "(" + \
-            "%.2f" % ((len(unpaired_reads[0]) + len(unpaired_reads[1]) / total_pairs)*100) + "%)")
+            "%.2f" % (((len(unpaired_reads[0]) + len(unpaired_reads[1])) / total_pairs)*100) + "%)")
     else:
         total_pairs = read_results['total']
         print("  Total input reads:", total_pairs)


### PR DESCRIPTION
A collaborator tried to run Hornet with `python ./Hornet/mapping/find_intersecting_snps.py -p -C 1 file.bam chr_files ` but chr files consisted of only the file `chr1.snps.txt.gz`. Hornet does not try to remove the `chr` from names, so this silently led to an error.

In parallel, there has been an error in the calculation of unpaired reads where we were essentially doing:

`unpaired1 + unpaired2/total` instead of `(unpaired 1 + unpaired 2)/total`.  

Add in the fact that total was all reads, not just all reads on the selected chromosome, and this was very confusing.